### PR TITLE
Disable sched boost

### DIFF
--- a/init/vendor/etc/init/hw/init.target.rc
+++ b/init/vendor/etc/init/hw/init.target.rc
@@ -31,7 +31,7 @@ on early-init
     mkdir /bt_firmware 0771 system system
     symlink /data/tombstones /tombstones
     mkdir /dsp 0771 media media
-    write /proc/sys/kernel/sched_boost 1
+    write /proc/sys/kernel/sched_boost 0
 
 on init
     write /dev/stune/foreground/schedtune.sched_boost_no_override 1


### PR DESCRIPTION
* This forces cores to remain at max freq. For some unknown reason
  OnePlus thought this would be a good idea to apply in post boot
  but override that echo in init while in system. Let's change that!

Let's also give some credit to @nathanchance for the assist.

Change-Id: I2b3f54504271b37884e3621894023dca38040e43